### PR TITLE
[cosmetic-readme-1770798544039] Fix the typo "repositry" to "repository" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Momentous Orchestra E2E Test Repo
 
-This is a test repositry for validating the orchestration pipeline.
+This is a test repository for validating the orchestration pipeline.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
## Summary

I've successfully fixed the typo in README.md:
- **File:** README.md:3
- **Change:** Fixed "repositry" → "repository"

The typo has been corrected and the README.md file now displays the proper spelling of "repository" in the description line.

## Changes


Closes #11