### PR TITLE
[multi-copyright-1770800369531] Add a copyright header comment to the top of src/utils.ts

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,8 @@
 /**
+ * Copyright (c) 2026. All rights reserved.
+ */
+
+/**
  * Greets a person by name.
  */
 export function greet(name: string): string {


### PR DESCRIPTION
## Summary
Perfect! I've successfully added a copyright header comment to the top of `src/utils.ts`.

## Summary

I added a copyright header comment at the top of the file using a standard format:
```typescript
/**
 * Copyright (c) 2026. All rights reserved.
 */
```

The copyright header is now positioned at the very beginning of the file, before the existing function documentation comments. The change maintains the existing code structure and follows standard copyright notice conventions.

## Changes


Closes #26