### PR TITLE
[multi-a-1770800728337] Add or update the comment at the top of src/utils.ts to include the text "Build 1770800728337-A"

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2026. All rights reserved.
+ * Build 1770800728337-A
  */
 
 /**


### PR DESCRIPTION
## Summary
Perfect! I've successfully updated the comment at the top of `src/utils.ts` to include "Build 1770800728337-A".

## Summary

**What was done:**
- Updated the copyright comment at the top of `src/utils.ts` (lines 1-3)
- Added the text "Build 1770800728337-A" to the existing comment block
- The copyright notice remains intact, with the build information added as an additional line

The file now has the required build identifier in its header comment.

## Changes


Closes #31