### PR TITLE
[telemetry-iso-b-1770820726732] Add a padStart(str, targetLen, padChar) function to src/utils.ts that pads the start of a string to reach targetLen

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,3 +96,15 @@ export function truncate(str: string, maxLen: number): string {
   }
   return str.slice(0, maxLen) + '...';
 }
+
+/**
+ * Pads the start of a string to reach a target length.
+ */
+export function padStart(str: string, targetLen: number, padChar: string): string {
+  if (str.length >= targetLen) {
+    return str;
+  }
+  const padLength = targetLen - str.length;
+  const padding = padChar.repeat(Math.ceil(padLength / padChar.length)).slice(0, padLength);
+  return padding + str;
+}


### PR DESCRIPTION
## Summary
Perfect! I've successfully implemented the `padStart` function in `src/utils.ts`. Here's a summary of what was done:

## Summary

**Added `padStart(str, targetLen, padChar)` function** to `src/utils.ts`:
- Pads the start of a string to reach the target length
- If the string is already at or exceeds the target length, it returns the original string unchanged
- Handles padding characters of any length by repeating and slicing as needed
- Follows the existing code style with JSDoc comments
- Locat

## Changes


Closes #42