### PR TITLE
[multi-a-1770820822365] Add or update the comment at the top of src/utils.ts to include the text "Build 1770820822365-A"

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2026. All rights reserved.
- * Build 1770800728337-A
+ * Build 1770820822365-A
  */
 
 /**


### PR DESCRIPTION
## Summary
Excellent! I've successfully updated the build number in the comment at the top of `src/utils.ts`.

## Summary

✅ **Task Completed**

**Changes Made:**
- Updated the build number in the header comment of `src/utils.ts` from "Build 1770800728337-A" to "Build 1770820822365-A" (line 3)

The file now contains the correct build identifier "Build 1770820822365-A" as specified in the acceptance criteria.

## Changes


Closes #45