### PR TITLE
[multi-a-1770822256787] Add or update the comment at the top of src/utils.ts to include the text "Build 1770822256787-A"

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2026. All rights reserved.
- * Build 1770820822365-A
+ * Build 1770822256787-A
  */
 
 /**


### PR DESCRIPTION
## Summary
Excellent! I've successfully updated the build number in the comment at the top of `src/utils.ts`.

## Summary

**Changes made:**
- Updated the build number in the file header comment from "Build 1770820822365-A" to "Build 1770822256787-A" at line 3 of `src/utils.ts`

The file now correctly displays the new build number "Build 1770822256787-A" in the copyright header comment, meeting the acceptance criteria for this task.

## Changes


Closes #62