### PR TITLE
[telemetry-iso-b-1770823240720] Add a padStart(str, targetLen, padChar) function to src/utils.ts that pads the start of a string to reach targetLen

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,3 +28,14 @@ export function truncate(str: string, maxLen: number): string {
   }
   return str.slice(0, maxLen) + '...';
 }
+
+/**
+ * Pads the start of a string to reach targetLen using padChar.
+ */
+export function padStart(str: string, targetLen: number, padChar: string): string {
+  if (str.length >= targetLen) {
+    return str;
+  }
+  const padLength = targetLen - str.length;
+  return padChar.repeat(padLength) + str;
+}


### PR DESCRIPTION
## Summary
## Summary

I've successfully implemented the `padStart` function in `src/utils.ts` at line 36-42. The function:

- Takes three parameters: `str` (string to pad), `targetLen` (target length), and `padChar` (character to pad with)
- Returns the original string if it's already at or above the target length
- Calculates the padding needed and repeats `padChar` to fill the gap
- Prepends the padding to the start of the string
- Follows the existing code style with proper documentation and TypeScript

## Changes


Closes #69