### PR TITLE
[cosmetic-readme-1770823583979] Fix the typo "repositry" to "repository" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Momentous Orchestra E2E Test Repo
 
-This is a test repositry for validating the orchestration pipeline.
+This is a test repository for validating the orchestration pipeline.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
Perfect! I've successfully fixed the typo in the README.md file.

## Summary

Fixed the typo on line 3 of README.md:
- Changed "repositry" to "repository"

The file now correctly reads: "This is a test repository for validating the orchestration pipeline."

## Changes


Closes #78