### PR TITLE
[telemetry-iso-b-1770824030595] Add a padStart(str, targetLen, padChar) function to src/utils.ts that pads the start of a string to reach targetLen

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,3 +28,14 @@ export function truncate(str: string, maxLen: number): string {
   }
   return str.slice(0, maxLen) + '...';
 }
+
+/**
+ * Pads the start of a string to reach the target length.
+ */
+export function padStart(str: string, targetLen: number, padChar: string): string {
+  if (str.length >= targetLen) {
+    return str;
+  }
+  const padLength = targetLen - str.length;
+  return padChar.repeat(padLength) + str;
+}


### PR DESCRIPTION
## Summary
Perfect! I've successfully implemented the `padStart` function in `src/utils.ts`.

## Summary

I've added the `padStart(str, targetLen, padChar)` function to `src/utils.ts` at line 33-39. The implementation:

- Takes three parameters: `str` (the string to pad), `targetLen` (the target length), and `padChar` (the character to use for padding)
- Returns the original string if it's already at or above the target length
- Calculates how many padding characters are needed and prepends them to the str

## Changes


Closes #91