### PR TITLE
[cosmetic-readme-1770824562204] Fix the typo "repositry" to "repository" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Momentous Orchestra E2E Test Repo
 
-This is a test repositry for validating the orchestration pipeline.
+This is a test repository for validating the orchestration pipeline.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
## Summary

I've successfully fixed the typo in README.md:3. Changed "repositry" to "repository" in the description line. The file now correctly reads "This is a test repository for validating the orchestration pipeline."

## Changes


Closes #108